### PR TITLE
Release v3.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # signNow API PHP SDK
-## v3.5.1
+## v3.5.2
 
 [![PHP Version](https://img.shields.io/badge/supported->=8.2-blue?logo=php)](https://php.net/)
 
@@ -11,7 +11,7 @@
 ### Installation
 Get SDK code via composer
 ```bash
-composer require signnow/api-php-sdk:v3.5.1
+composer require signnow/api-php-sdk:v3.5.2
 ```
 or via git
 ```bash

--- a/src/SignNow/Core/Config/ConfigDefaults.php
+++ b/src/SignNow/Core/Config/ConfigDefaults.php
@@ -16,6 +16,7 @@ namespace SignNow\Core\Config;
 final readonly class ConfigDefaults
 {
     public const SIGNNOW_API_HOST = 'https://api.signnow.com';
+    public const SIGNNOW_API_TIMEOUT = 30;
     public const USERNAME = '';
     public const PASSWORD = '';
     public const BASIC_TOKEN = '';

--- a/src/SignNow/Core/Config/ConfigLoader.php
+++ b/src/SignNow/Core/Config/ConfigLoader.php
@@ -47,6 +47,7 @@ class ConfigLoader
             'signnow_api_basic_token' => $this->getEnvOrDefault('SIGNNOW_API_BASIC_TOKEN', ConfigDefaults::BASIC_TOKEN),
             'signnow_api_host' => $this->getEnvOrDefault('SIGNNOW_API_HOST', ConfigDefaults::SIGNNOW_API_HOST),
             'signnow_downloads_dir' => $this->getEnvOrDefault('SIGNNOW_DOWNLOADS_DIR', ConfigDefaults::DOWNLOADS_DIR),
+            'signnow_api_timeout' => getenv('SIGNNOW_API_TIMEOUT') ?? ConfigDefaults::SIGNNOW_API_TIMEOUT,
         ];
     }
 

--- a/src/SignNow/Core/Config/ConfigRepository.php
+++ b/src/SignNow/Core/Config/ConfigRepository.php
@@ -17,9 +17,10 @@ use SignNow\Core\Token\BasicToken;
 
 class ConfigRepository
 {
-    private const CLIENT_NAME = 'SignNowApiClient/v3.5.1 (PHP)';
-    private const TIMEOUT = 10;
+    private const CLIENT_NAME = 'SignNowApiClient/v3.5.2 (PHP)';
+    private const DEFAULT_TIMEOUT = 30;
     private const HOST = 'signnow_api_host';
+    private const TIMEOUT = 'signnow_api_timeout';
     private const USERNAME = 'signnow_api_username';
     private const PASSWORD = 'signnow_api_password';
     private const BASIC_TOKEN = 'signnow_api_basic_token';
@@ -57,7 +58,9 @@ class ConfigRepository
 
     public function timeout(): int
     {
-        return self::TIMEOUT;
+        return !empty($this->config[self::TIMEOUT])
+            ? (int) $this->config[self::TIMEOUT]
+            : self::DEFAULT_TIMEOUT;
     }
 
     public function projectDirectory(): string


### PR DESCRIPTION
Default API timeout increased from 10 to 30 seconds.
Added configurable timeout via `SIGNNOW_API_TIMEOUT` environment variable. 
Timeout can now be customized through environment variables or config files.