### PR TITLE
SignNow rebrand in LICENSE + README, expand .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,41 @@
+# Dependencies
 /vendor
+composer.lock
+
+# Build / output
+/build
+/dist
+
+# Test / cache
+.phpunit.cache/
+.phpunit.result.cache
+phpcs-report.xml
+.php-cs-fixer.cache
+
+# IDE
 /.idea
 /.fleet
 /.vscode
 /.netbeans
-composer.lock
+.phpactor.json
+
+# Editor swap files
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Environment / credentials
 .env
+.env.local
 .env.backup
 .env.test
 .env.production
 .env.development
-.phpactor.json
+
+# Project-local examples / fixtures
 examples/signnow-example-config.php
 examples/_data/bulk_real.csv

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # The MIT License
 
-Copyright (c) 2003-2019 airSlate Inc. [LICENSE](https://github.com/signnow/SignNowPHPSDK/blob/master/LICENSE.md)
+Copyright (c) 2003-2026 SignNow
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# signNow API PHP SDK
+# SignNow API PHP SDK
 ## v3.5.3
 
 [![PHP Version](https://img.shields.io/badge/supported->=8.2-blue?logo=php)](https://php.net/)


### PR DESCRIPTION
LICENSE.md: replace 'airSlate Inc.' (2003-2019) legacy copyright with 'SignNow' (2003-2026); drop redundant self-link.
README.md: H1 'signNow' -> 'SignNow' to match peer SDKs.
.gitignore: add OS files (.DS_Store, Thumbs.db), editor swap files, build/dist/, PHPUnit caches, .php-cs-fixer.cache, .env.local; group with section headers.