### PR TITLE
Allow float width/height in document page Size

### DIFF
--- a/src/SignNow/Api/Document/Response/Data/Size.php
+++ b/src/SignNow/Api/Document/Response/Data/Size.php
@@ -16,17 +16,17 @@ namespace SignNow\Api\Document\Response\Data;
 readonly class Size
 {
     public function __construct(
-        private int $width,
-        private int $height,
+        private float|int $width,
+        private float|int $height,
     ) {
     }
 
-    public function getWidth(): int
+    public function getWidth(): float|int
     {
         return $this->width;
     }
 
-    public function getHeight(): int
+    public function getHeight(): float|int
     {
         return $this->height;
     }


### PR DESCRIPTION
## Problem

`GET /document/{document_id}` can return non-integer page dimensions in `pages[].size`, e.g.:

```json
"pages": [
  {
    "src": "...",
    "size": { "width": 612, "height": 791.99 }
  }
]
```

Since `Size` is declared under `strict_types=1` with `int` constructor parameters, `Size::fromArray()` throws an uncatchable-in-practice `TypeError` whenever the API returns a float, which breaks `DocumentGet` deserialization for such documents.

## Fix

Widen `width`/`height` in `SignNow\Api\Document\Response\Data\Size` from `int` to `float|int` (constructor and getters). Integer values keep round-tripping as integers through `toArray()`; float values no longer fatal.

`phpcs` passes on the changed file.